### PR TITLE
Split docker dev and prod build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM python:3.10-slim-buster
+FROM python:3.10-slim-buster as build
 
 EXPOSE 8000
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK 1
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
+ENV PORT 8000
 
 RUN pip install --no-cache-dir --upgrade pip
 RUN pip install gunicorn==20.1.0
@@ -14,3 +15,26 @@ RUN pip install --no-cache-dir -r /requirements.txt
 
 WORKDIR /app
 COPY management_interface /app
+
+FROM build AS dev
+
+# This is the stage which docker-compose launches for you.
+# It doesn't specify a CMD; that's overridden in
+# docker-compose.yml.
+
+# build-essential gives us make, among other niceties.
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install -y build-essential
+
+FROM build AS prod
+
+# This is the production stage; we don't have nonessential
+# apt packages in this stage.
+
+# Reset our WORKDIR because the outer directory isn't needed
+WORKDIR /app/management_interface
+
+# See bin/serve for some (quite involved) gunicorn settings.
+CMD ["bin/serve"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: "3.9"
 services:
   web:
-    build: .
+    build:
+      context: .
+      target: dev
     ports:
       - "8000:8000"
     command: python management_interface/manage.py runserver 0.0.0.0:8000

--- a/management_interface/bin/serve
+++ b/management_interface/bin/serve
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export PORT=${PORT:-8000}
+
+gunicorn --worker-tmp-dir /dev/shm \
+  --workers=2 \
+  --threads=4 \
+  --worker-class=gthread \
+  --log-file=- \
+  --bind=0:${PORT} \
+  management_interface.wsgi


### PR DESCRIPTION
This patch makes the Dockerfile build both `dev` and `prod` images.  If built with `docker build` it will default to building the `prod` stage, which gives us a place to put development-specific build dependencies.

The `dev` stage is mostly an example at the moment: it installs `build-essential` which I wanted for some local `make` tasks, but we may want to add to it in future.

One important difference between the `dev` and `prod` stages is that the `prod` stage is configured to run the `gunicorn` server via the script in `management_interface/bin/serve` which, since it's listed in the `Dockerfile`, I assume we want to use.  I've tweaked the workers and threads to be somewhat sensible values, and for the logs to go to stdout.

As long as you're running it through `docker-compose`, the `dev` stage will still run the `django` development server rather than `gunicorn`.