### PR TITLE
Remove the outer directory from what's in the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY requirements.txt /
 RUN pip install --no-cache-dir -r /requirements.txt
 
 WORKDIR /app
-COPY management_interface /app
+COPY management_interface /app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,17 +7,17 @@ services:
     # probably a hack: createsuperuser would fail if issued on existing DB (as the user already exists)
     # so to allow build command to finish and run the container, we force to ignore the error
     command: >
-      sh -c "python management_interface/manage.py migrate
-      && python management_interface/manage.py collectstatic --no-input
-      && python management_interface/manage.py createsuperuser --noinput || true
-      && python management_interface/manage.py runserver 0.0.0.0:8000"
+      sh -c "python manage.py migrate
+      && python manage.py collectstatic --no-input
+      && python manage.py createsuperuser --noinput || true
+      && python manage.py runserver 0.0.0.0:8000"
     volumes:
-      - .:/app
+      - ./management_interface:/app
     environment:
-      - "DJANGO_SUPERUSER_PASSWORD=${DJANGO_SUPERUSER_PASSWORD}"
-      - "DJANGO_SUPERUSER_USERNAME=${DJANGO_SUPERUSER_USERNAME}"
-      - "DJANGO_SUPERUSER_EMAIL=${DJANGO_SUPERUSER_EMAIL}"
-      - "HANS_MI_DEBUG=${HANS_MI_DEBUG}"
+      - "DJANGO_SUPERUSER_PASSWORD=${DJANGO_SUPERUSER_PASSWORD:-admin}"
+      - "DJANGO_SUPERUSER_USERNAME=${DJANGO_SUPERUSER_USERNAME:-admin}"
+      - "DJANGO_SUPERUSER_EMAIL=${DJANGO_SUPERUSER_EMAIL:-hans_admin@thepsc.co.uk}"
+      - "HANS_MI_DEBUG=${HANS_MI_DEBUG:-TRUE}"
     depends_on:
       - db
   db:


### PR DESCRIPTION
This is a minor rearrangement which aligns the `docker-compose` volume mount with the `Dockerfile` so that the outer `management_interface` directory isn't copied into the container.